### PR TITLE
Refactor callback attach function to take event param

### DIFF
--- a/OneButtonC.c
+++ b/OneButtonC.c
@@ -148,41 +148,41 @@ bool OB_IsLongPressed(const OneButton_t* btn) {
 
 bool OB_AttachCallback(OneButton_t* btn, OneButtonEvent event, OneButtonCallback cb) {
     if (!btn) {
-        return;
+        return false;
     }
 
     switch (event) {
-        case OB_EVENT_PRESS:
+        case OB_EV_PRESS:
             btn->pressFunc = cb;
             break;
 
-        case OB_EVENT_CLICK:
+        case OB_EV_CLICK:
             btn->clickFunc = cb;
             break;
 
-        case OB_EVENT_DOUBLE_CLICK:
+        case OB_EV_DOUBLE_CLICK:
             btn->doubleClickFunc = cb;
             btn->maxClicks = btn->maxClicks > 2 ? btn->maxClicks : 2;
             break;
 
-        case OB_EVENT_MULTI_CLICK:
+        case OB_EV_MULTI_CLICK:
             btn->multiClickFunc = cb;
             btn->maxClicks = btn->maxClicks > 100 ? btn->maxClicks : 100;
             break;
 
-        case OB_EVENT_LONG_PRESS_START:
+        case OB_EV_LONG_PRESS_START:
             btn->longPressStartFunc = cb;
             break;
 
-        case OB_EVENT_LONG_PRESS_STOP:
+        case OB_EV_LONG_PRESS_STOP:
             btn->longPressStopFunc = cb;
             break;
 
-        case OB_EVENT_DURING_LONG_PRESS:
+        case OB_EV_DURING_LONG_PRESS:
             btn->duringLongPressFunc = cb;
             break;
 
-        case OB_EVENT_IDLE:
+        case OB_EV_IDLE:
             btn->idleFunc = cb;
             break;
 

--- a/OneButtonC.c
+++ b/OneButtonC.c
@@ -146,38 +146,52 @@ bool OB_IsLongPressed(const OneButton_t* btn) {
     return btn->state == OCS_PRESS;
 }
 
-void OB_AttachPress(OneButton_t* btn, OneButtonCallback cb) {
-    btn->pressFunc = cb;
-}
+bool OB_AttachCallback(OneButton_t* btn, OneButtonEvent event, OneButtonCallback cb) {
+    if (!btn) {
+        return;
+    }
 
-void OB_AttachClick(OneButton_t* btn, OneButtonCallback cb) {
-    btn->clickFunc = cb;
-}
+    switch (event) {
+        case OB_EVENT_PRESS:
+            btn->pressFunc = cb;
+            break;
 
-void OB_AttachDoubleClick(OneButton_t* btn, OneButtonCallback cb) {
-    btn->doubleClickFunc = cb;
-    btn->maxClicks = btn->maxClicks > 2 ? btn->maxClicks : 2;
-}
+        case OB_EVENT_CLICK:
+            btn->clickFunc = cb;
+            break;
 
-void OB_AttachMultiClick(OneButton_t* btn, OneButtonCallback cb) {
-    btn->multiClickFunc = cb;
-    btn->maxClicks = btn->maxClicks > 100 ? btn->maxClicks : 100;
-}
+        case OB_EVENT_DOUBLE_CLICK:
+            btn->doubleClickFunc = cb;
+            btn->maxClicks = btn->maxClicks > 2 ? btn->maxClicks : 2;
+            break;
 
-void OB_AttachLongPressStart(OneButton_t* btn, OneButtonCallback cb) {
-    btn->longPressStartFunc = cb;
-}
+        case OB_EVENT_MULTI_CLICK:
+            btn->multiClickFunc = cb;
+            btn->maxClicks = btn->maxClicks > 100 ? btn->maxClicks : 100;
+            break;
 
-void OB_AttachLongPressStop(OneButton_t* btn, OneButtonCallback cb) {
-    btn->longPressStopFunc = cb;
-}
+        case OB_EVENT_LONG_PRESS_START:
+            btn->longPressStartFunc = cb;
+            break;
 
-void OB_AttachDuringLongPress(OneButton_t* btn, OneButtonCallback cb) {
-    btn->duringLongPressFunc = cb;
-}
+        case OB_EVENT_LONG_PRESS_STOP:
+            btn->longPressStopFunc = cb;
+            break;
 
-void OB_AttachIdle(OneButton_t* btn, OneButtonCallback cb) {
-    btn->idleFunc = cb;
+        case OB_EVENT_DURING_LONG_PRESS:
+            btn->duringLongPressFunc = cb;
+            break;
+
+        case OB_EVENT_IDLE:
+            btn->idleFunc = cb;
+            break;
+
+        default:
+            return false;  // Invalid event type
+    }
+
+    return true;
+
 }
 
 uint16_t OB_GetPressedMs(const OneButton_t* btn) {

--- a/OneButtonC.h
+++ b/OneButtonC.h
@@ -86,6 +86,17 @@ typedef struct {
   OneButtonCallback idleFunc;
 } OneButton_t;
 
+typedef enum {
+  OB_EV_PRESS,
+  OB_EV_CLICK,
+  OB_EV_DOUBLE_CLICK,
+  OB_EV_MULTI_CLICK,
+  OB_EV_LONG_PRESS_START,
+  OB_EV_LONG_PRESS_STOP,
+  OB_EV_DURING_LONG_PRESS,
+  OB_EV_IDLE
+} OneButtonEvent;
+
 // ----- Function prototypes -----
 
 void OB_Init(OneButton_t* btn);
@@ -105,15 +116,8 @@ void OB_SetPressMs(OneButton_t* btn, uint16_t ms);
 void OB_SetIdleMs(OneButton_t* btn, uint16_t ms);
 void OB_SetLongPressIntervalMs(OneButton_t* btn, uint16_t ms);
 
-// Attach callback function Prototypes
-void OB_AttachPress(OneButton_t* btn, OneButtonCallback cb);
-void OB_AttachClick(OneButton_t* btn, OneButtonCallback cb);
-void OB_AttachDoubleClick(OneButton_t* btn, OneButtonCallback cb);
-void OB_AttachMultiClick(OneButton_t* btn, OneButtonCallback cb);
-void OB_AttachLongPressStart(OneButton_t* btn, OneButtonCallback cb);
-void OB_AttachLongPressStop(OneButton_t* btn, OneButtonCallback cb);
-void OB_AttachDuringLongPress(OneButton_t* btn, OneButtonCallback cb);
-void OB_AttachIdle(OneButton_t* btn, OneButtonCallback cb);
+// Replace all individual attach function prototypes with this single function
+bool OB_AttachCallback(OneButton_t* btn, OneButtonEvent event, OneButtonCallback cb);
 
 // Getter functions
 uint16_t OB_GetPressedMs(const OneButton_t* btn);

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ void B1_press() { // Basic function to count button presses
 }
 
 // Setup callback function
-OB_AttachCallback(&button1, OB_EVENT_PRESS, B1_press)
+OB_AttachCallback(&button1, OB_EV_PRESS, B1_press)
 
 while (1) {
     OB_Tick(&button1); // Call ticks in main loop
@@ -73,7 +73,7 @@ void B1_press() { // Basic function to count button presses
     press_cnt++;
 }
 
-OB_AttachCallback(&button1, OB_EVENT_PRESS, B1_press); // Attach the B1_press function to the OB_EVENT_PRESS event for button1.
+OB_AttachCallback(&button1, OB_EV_PRESS, B1_press); // Attach the B1_press function to the OB_EV_PRESS event for button1.
 ```
 
 ### Don't forget to `OB_Tick()`

--- a/README.md
+++ b/README.md
@@ -28,7 +28,8 @@ void B1_press() { // Basic function to count button presses
     press_cnt++;
 }
 
-OB_AttachPress(&button1, B1_press); // Attach the B1_press function to the Press action
+// Setup callback function
+OB_AttachCallback(&button1, OB_EVENT_PRESS, B1_press)
 
 while (1) {
     OB_Tick(&button1); // Call ticks in main loop
@@ -72,7 +73,7 @@ void B1_press() { // Basic function to count button presses
     press_cnt++;
 }
 
-OB_AttachPress(&button1, B1_press); // Attach the B1_press function to the Press action
+OB_AttachCallback(&button1, OB_EVENT_PRESS, B1_press); // Attach the B1_press function to the OB_EVENT_PRESS event for button1.
 ```
 
 ### Don't forget to `OB_Tick()`
@@ -96,15 +97,19 @@ Note that the 'OB_Tick()' function uses the `HAL_GPIO_ReadPin( GPIO_TypeDef* GPI
 
 Here's a full list of events handled by this library:
 
-| Attach Function         | Description                                                   |
+| One Button Events         | Description                                                   |
 | ----------------------- | ------------------------------------------------------------- |
-| `OB_AttachPress`        | Fires as soon as a press is detected.                         |
-| `OB_AttachClick`        | Fires as soon as a single click press and release is detected.|
-| `OB_AttachDoubleClick`  | Fires as soon as a double click is detected.                  |
-| `OB_AttachMultiClick`   | Fires as soon as multiple clicks have been detected.          |
-| `OB_AttachLongPressStart` | Fires as soon as the button is held down for the defined (ms).|
-| `OB_AttachDuringLongPress` | Fires periodically as long as the button is held down.        |
-| `OB_AttachLongPressStop` | Fires when the button is released after a long hold.          |
+| `OB_EV_PRESS`        | Fires as soon as a press is detected.                         |
+| `OB_EV_CLICK`        | Fires as soon as a single click press and release is detected.|
+| `OB_EV_DOUBLE_CLICK`  | Fires as soon as a double click is detected.                  |
+| `OB_EV_MULTI_CLICK`   | Fires as soon as multiple clicks have been detected.          |
+| `OB_EV_LONG_PRESS_START` | Fires as soon as the button is held down for the defined (ms).|
+| `OB_EV_LONG_PRESS_STOP` | Fires periodically as long as the button is held down.        |
+| `OB_EV_DURING_LONG_PRESS` | Fires when the button is released after a long hold.          |
+| `OB_EV_IDLE` | Fires when the button is determined to be idle.          |
+
+These event ares attached to the callback function using the generic attach function:
+`OB_AttachCallback(OneButton_t* btn, OneButtonEvent event, OneButtonCallback cb);`
 
 ### Event Timing
 
@@ -122,7 +127,7 @@ __Note:__ Attaching a double click will increase the delay for detecting a singl
 
 You may change these default values but be aware that when you specify too short times it is hard to click twice or you will create a long press instead of a click.
 
-Set debounce (ms) to a negative value to only debounce on release. `OB_SetDebounceMs(-25);` will immediately update to a pressed state, and will debounce for 25ms going into the released state. This will expedite the `OB_AttachPress` callback function to run instantly.
+Set debounce (ms) to a negative value to only debounce on release. `OB_SetDebounceMs(-25);` will immediately update to a pressed state, and will debounce for 25ms going into the released state. This will expedite the `OB_EV_PRESS` event callback function to run instantly.
 
 Note that long press is not activated by default as it will mask other button functions.
 


### PR DESCRIPTION
Clean up code by removing the multiple callback attach functions in favor of a single function taking the button event param and use a switch case.

Update docs to reflect these changes.